### PR TITLE
[회원 관리] Context를 ViewModel 및 Repository에 전달하지 않도록 수정

### DIFF
--- a/app/src/main/java/com/fintern/ourbudgeting/data/auth/GoogleSignInClient.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/data/auth/GoogleSignInClient.kt
@@ -1,0 +1,31 @@
+package com.fintern.ourbudgeting.data.auth
+
+import android.content.Context
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import com.fintern.ourbudgeting.BuildConfig
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import javax.inject.Inject
+
+class GoogleSignInClient @Inject constructor(
+    private val context: Context,
+    private val credentialManager: CredentialManager
+) {
+    suspend fun getGoogleIdToken(): String {
+        val googleIdOption = GetGoogleIdOption.Builder()
+            .setFilterByAuthorizedAccounts(false)
+            .setServerClientId(BuildConfig.GOOGLE_CLIENT_ID)
+            .build()
+
+        val request = GetCredentialRequest.Builder()
+            .addCredentialOption(googleIdOption)
+            .build()
+
+        val result = credentialManager.getCredential(context, request)
+        val credential = result.credential
+
+        val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
+        return googleIdTokenCredential.idToken
+    }
+}

--- a/app/src/main/java/com/fintern/ourbudgeting/data/auth/GoogleSignInClient.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/data/auth/GoogleSignInClient.kt
@@ -1,6 +1,7 @@
 package com.fintern.ourbudgeting.data.auth
 
 import android.content.Context
+import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import com.fintern.ourbudgeting.BuildConfig
@@ -27,5 +28,11 @@ class GoogleSignInClient @Inject constructor(
 
         val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
         return googleIdTokenCredential.idToken
+    }
+
+    suspend fun clearCredentialState() {
+        credentialManager.clearCredentialState(
+            ClearCredentialStateRequest()
+        )
     }
 }

--- a/app/src/main/java/com/fintern/ourbudgeting/data/repository/GoogleAuthRepository.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/data/repository/GoogleAuthRepository.kt
@@ -1,12 +1,7 @@
 package com.fintern.ourbudgeting.data.repository
 
-import android.content.Context
 import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.CredentialManager
-import androidx.credentials.GetCredentialRequest
-import com.fintern.ourbudgeting.BuildConfig
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
-import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GoogleAuthProvider
@@ -18,28 +13,10 @@ class GoogleAuthRepository @Inject constructor(
     private val auth: FirebaseAuth
 ) {
 
-    suspend fun signInWithGoogle(context: Context): FirebaseUser? {
-        val googleIdOption = GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false)
-            .setServerClientId(BuildConfig.GOOGLE_CLIENT_ID)
-            .build()
-
-        val request = GetCredentialRequest.Builder()
-            .addCredentialOption(googleIdOption)
-            .build()
-
+    suspend fun signInWithGoogle(googleIdToken: String): FirebaseUser? {
         return try {
-            val result = credentialManager.getCredential(context, request)
-            val credential = result.credential
-
-            // GoogleIdTokenCredential을 사용하여 id를 추출하여 유효성 검사한 후, 서버에서 인증
-            val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
-            val googleIdToken = googleIdTokenCredential.idToken
-
             val firebaseCredential = GoogleAuthProvider.getCredential(googleIdToken, null)
-
             auth.signInWithCredential(firebaseCredential).await().user
-
         } catch (e: Exception) {
             // TODO: 예외 처리
             null

--- a/app/src/main/java/com/fintern/ourbudgeting/data/repository/GoogleAuthRepository.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/data/repository/GoogleAuthRepository.kt
@@ -1,7 +1,5 @@
 package com.fintern.ourbudgeting.data.repository
 
-import androidx.credentials.ClearCredentialStateRequest
-import androidx.credentials.CredentialManager
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GoogleAuthProvider
@@ -9,7 +7,6 @@ import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 class GoogleAuthRepository @Inject constructor(
-    private val credentialManager: CredentialManager,
     private val auth: FirebaseAuth
 ) {
 
@@ -23,11 +20,8 @@ class GoogleAuthRepository @Inject constructor(
         }
     }
 
-    suspend fun signOutWithGoogle() {
+    fun signOutWithGoogle() {
         auth.signOut()
-        credentialManager.clearCredentialState(
-            ClearCredentialStateRequest()
-        )
     }
 
     fun getCurrentUser(): FirebaseUser? {

--- a/app/src/main/java/com/fintern/ourbudgeting/di/AuthModule.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/di/AuthModule.kt
@@ -36,9 +36,8 @@ object AuthModule {
     @Provides
     @Singleton
     fun provideGoogleAuthRepository(
-        credentialManager: CredentialManager,
         firebaseAuth: FirebaseAuth
     ): GoogleAuthRepository {
-        return GoogleAuthRepository(credentialManager, firebaseAuth)
+        return GoogleAuthRepository(firebaseAuth)
     }
 }

--- a/app/src/main/java/com/fintern/ourbudgeting/di/AuthModule.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/di/AuthModule.kt
@@ -2,6 +2,7 @@ package com.fintern.ourbudgeting.di
 
 import android.content.Context
 import androidx.credentials.CredentialManager
+import com.fintern.ourbudgeting.data.auth.GoogleSignInClient
 import com.fintern.ourbudgeting.data.repository.GoogleAuthRepository
 import com.google.firebase.auth.FirebaseAuth
 import dagger.Module
@@ -21,6 +22,15 @@ object AuthModule {
         @ApplicationContext context: Context
     ): CredentialManager {
         return CredentialManager.create(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGoogleSignInClient(
+        @ApplicationContext context: Context,
+        credentialManager: CredentialManager
+    ): GoogleSignInClient {
+        return GoogleSignInClient(context, credentialManager)
     }
 
     @Provides

--- a/app/src/main/java/com/fintern/ourbudgeting/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/ui/login/LoginScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -28,7 +27,6 @@ fun LoginScreen(
     loginViewModel: LoginViewModel = hiltViewModel()
 ) {
     val uiState by loginViewModel.uiState.collectAsState()
-    val context = LocalContext.current
 
     LaunchedEffect(uiState.currentUser) {
         if (uiState.currentUser != null) {
@@ -48,7 +46,7 @@ fun LoginScreen(
         Image(
             painter = painterResource(R.drawable.ic_google_login),
             contentDescription = "로그인 버튼",
-            modifier = Modifier.clickable { loginViewModel.signInWithGoogle(context) }
+            modifier = Modifier.clickable { loginViewModel.signInWithGoogle() }
         )
     }
 }

--- a/app/src/main/java/com/fintern/ourbudgeting/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/ui/login/LoginViewModel.kt
@@ -1,8 +1,8 @@
 package com.fintern.ourbudgeting.ui.login
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.fintern.ourbudgeting.data.auth.GoogleSignInClient
 import com.fintern.ourbudgeting.data.repository.GoogleAuthRepository
 import com.fintern.ourbudgeting.ui.user.UserViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,6 +14,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val authRepository: GoogleAuthRepository,
+    private val signInClient: GoogleSignInClient,
     private val userViewModel: UserViewModel,
 ) : ViewModel() {
 
@@ -24,12 +25,13 @@ class LoginViewModel @Inject constructor(
     )
     val uiState = _uiState.asStateFlow()
 
-    fun signInWithGoogle(context: Context) {
+    fun signInWithGoogle() {
         viewModelScope.launch {
             try {
-                val user = authRepository.signInWithGoogle(context)
+                val googleIdToken = signInClient.getGoogleIdToken()
+                val user = authRepository.signInWithGoogle(googleIdToken)
                 _uiState.value = _uiState.value.copy(currentUser = user)
-                userViewModel.updateUser(user?.uid ?: "", "닉네임")
+                user?.uid?.let { userViewModel.updateUser(it, "닉네임") }
             } catch (e: Exception) {
                 // TODO: 에러 처리
             }

--- a/app/src/main/java/com/fintern/ourbudgeting/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/ui/login/LoginViewModel.kt
@@ -31,7 +31,7 @@ class LoginViewModel @Inject constructor(
                 val googleIdToken = signInClient.getGoogleIdToken()
                 val user = authRepository.signInWithGoogle(googleIdToken)
                 _uiState.value = _uiState.value.copy(currentUser = user)
-                user?.uid?.let { userViewModel.updateUser(it, "닉네임") }
+                user?.uid?.let { userViewModel.updateUser(it, user.displayName.toString()) }
             } catch (e: Exception) {
                 // TODO: 에러 처리
             }

--- a/app/src/main/java/com/fintern/ourbudgeting/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/fintern/ourbudgeting/ui/login/LoginViewModel.kt
@@ -41,6 +41,7 @@ class LoginViewModel @Inject constructor(
     fun signOutWithGoogle() {
         viewModelScope.launch {
             authRepository.signOutWithGoogle()
+            signInClient.clearCredentialState()
             _uiState.value = _uiState.value.copy(currentUser = null)
         }
     }


### PR DESCRIPTION
📌 문제 배경
- 기존 구현에서는 Context를 ViewModel을 거쳐 Repository에 전달하고 있다.
- 이러한 구조는 lifecycle 관리 측면에서 안전하지 않고, 책임 분리 원칙에도 적합하지 않기 때문에 수정이 필요했다.

✅ 작업 목록
- Context가 필요한 작업은 따로 클래스를 생성하여 주입